### PR TITLE
Add `aoai_use_chat` option

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -241,9 +241,9 @@ impl Config {
             // If we're using OpenAI's API, always use the chat API
             true
         } else {
-            // If we're using Azure OpenAI, then use don't use the chat API unless we're on a model
-            // that only supports it.
-            self.aoai_use_chat.unwrap_or(false)
+            // If we're using Azure OpenAI, then use chat API unless we're on an
+            // older model that doesn't support it.
+            self.aoai_use_chat.unwrap_or(true)
         }
     }
 
@@ -603,8 +603,8 @@ fn create_config_file(config_path: &Path) -> Result<()> {
             .map_err(text_map_err)?;
         raw_config.push_str(&format!("aoai_deployment: {deployment}\n"));
 
-        let use_chat: bool = Confirm::new("Is that a chat-only model (e.g. GPT-4 preview)?")
-            .with_default(false)
+        let use_chat: bool = Confirm::new("Use chat API (not available for older models)?")
+            .with_default(true)
             .prompt()
             .map_err(text_map_err)?;
         raw_config.push_str(&format!("aoai_use_chat: {use_chat}\n"));

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -385,6 +385,11 @@ impl Config {
         let api_key = mask_text(&api_key, 3, 4);
         let aoai_endpoint = self.aoai_endpoint.clone().unwrap_or("-".into());
         let aoai_deployment = self.aoai_deployment.clone().unwrap_or("-".into());
+        let aoai_use_chat = self
+            .aoai_use_chat
+            .as_ref()
+            .map(|v| v.to_string())
+            .unwrap_or("-".into());
         let organization_id = organization_id
             .map(|v| mask_text(&v, 3, 4))
             .unwrap_or("-".into());
@@ -395,6 +400,7 @@ impl Config {
             ("api_key", api_key),
             ("aoai_endpoint", aoai_endpoint.to_string()),
             ("aoai_deployment", aoai_deployment.to_string()),
+            ("aoai_use_chat", aoai_use_chat),
             ("organization_id", organization_id),
             ("model", self.model.0.to_string()),
             ("temperature", temperature),


### PR DESCRIPTION
Add the `aoai_use_chat` option to force use of the Chat API - for other AOAI models the completions API offers more flexibility, but for e.g. the GPT-4 preview only the Chat API is available. 